### PR TITLE
Fix order of flags in gcc compilation command

### DIFF
--- a/.resources/rank03/level2/tsp/tester.sh
+++ b/.resources/rank03/level2/tsp/tester.sh
@@ -19,7 +19,7 @@ fi
 
 # Compile the program
 echo "${BLUE}Compiling tsp program...${RESET}"
-gcc -Wall -Werror -Wextra -lm -o tsp_test $c_files 2>/dev/null
+gcc -Wall -Werror -Wextra -o tsp_test $c_files -lm 2>/dev/null
 if [ $? -ne 0 ]; then
     echo "$(tput setaf 1)$(tput bold)FAIL: Compilation error$(tput sgr 0)"
     exit 1


### PR DESCRIPTION
BEFORE :
Compiling tsp program...
FAIL: Compilation error

AFTER :
Compiling tsp program...
Testing sub.txt 3x3 grid example...
Testing sub.txt square example...
Testing single point...
Testing two points...
Testing square (4 points)...
Testing floating point coordinates...
Testing empty input...
Testing collinear points...
PASSED 🎉