### PR TITLE
Fix for tester.sh in rank5 vect2 & bigint. (wrong include in main)

### DIFF
--- a/.resources/rank05/level1/bigint/tester.sh
+++ b/.resources/rank05/level1/bigint/tester.sh
@@ -37,6 +37,8 @@ echo -e "${BLUE}📦 Compiling user solution...${NC}"
 cp main.cpp user_main.cpp
 cp "$USER_HPP" user_bigint.hpp
 cp "$USER_CPP" user_bigint.cpp
+sed 's/#include "bigint.hpp"/#include "user_bigint.hpp"/' user_main.cpp > user_main.tmp.cpp
+mv user_main.tmp.cpp user_main.cpp
 g++ -Wall -Wextra -Werror -std=c++98 -o user_bigint user_main.cpp user_bigint.cpp
 if [ $? -ne 0 ]; then
     echo -e "${RED}❌ User compilation failed!${NC}"

--- a/.resources/rank05/level1/vect2/tester.sh
+++ b/.resources/rank05/level1/vect2/tester.sh
@@ -37,6 +37,8 @@ echo -e "${BLUE}📦 Compiling user solution...${NC}"
 cp main.cpp user_main.cpp
 cp "$USER_HPP" user_vect2.hpp
 cp "$USER_CPP" user_vect2.cpp
+sed 's/#include "vect2.hpp"/#include "user_vect2.hpp"/' user_main.cpp > user_main.tmp.cpp
+mv user_main.tmp.cpp user_main.cpp
 g++ -Wall -Wextra -Werror -std=c++98 -o user_vect2 user_main.cpp user_vect2.cpp
 if [ $? -ne 0 ]; then
     echo -e "${RED}❌ User compilation failed!${NC}"


### PR DESCRIPTION
In the current version of the tester, the copy of the main (user_main) was including bigint.hpp, preventing the user to compile with his own code. Changed it to include user_bigint.hpp