### PR TITLE
fix: Add -n to echo in count_non_space to avoid counting newline

### DIFF
--- a/.resources/rank03/level2/rip/tester.sh
+++ b/.resources/rank03/level2/rip/tester.sh
@@ -46,7 +46,7 @@ check_balanced() {
 # Function to count non-space characters
 count_non_space() {
     local str="$1"
-    echo "$str" | tr -d ' ' | wc -c | tr -d ' '
+    echo -n "$str" | tr -d ' ' | wc -c | tr -d ' '
 }
 
 # Test 1: Example from subject - rip '(()'


### PR DESCRIPTION
This fixes a small bug in the count_non_space function used in the RIP script under rank03/level2.
The function was incorrectly counting the trailing newline added by echo. Adding -n to echo prevents this, so the function now correctly counts only non-space characters.
I’m not very familiar with this script, so if I misunderstood and this isn’t actually an issue, please forgive me.