### PR TITLE
fix(test): initialize scanf output variables to avoid UB

### DIFF
--- a/.resources/rank03/level1/scanf/tester.sh
+++ b/.resources/rank03/level1/scanf/tester.sh
@@ -38,9 +38,9 @@ extern int ft_scanf(const char *, ...);
 
 int main(void)
 {
-    int num;
-    char str[100];
-    char c;
+    int num = -1;
+    char str[100] = {0};
+    char c = '?';
     
     // Test: %d %s %c
     int result = ft_scanf("%d %s %c", &num, str, &c);


### PR DESCRIPTION
This PR fixes undefined behavior in the scanf test script when the first conversion fails.

The issue occurs in `test1.c` during **Test 5: Invalid input** and **Test 6: EOF handling**. When the first conversion fails, `ft_scanf` does not write to any output arguments, but the test script still prints them.

As a result, the generated output may contain a null byte, and the lines
- actual=$(cat output5.txt)(line 179)
- actual=$(cat output6.txt)(line 190)

trigger the following shell warning:
- warning: command substitution: ignored null byte in input

This happens when an uninitialized `char` output evaluates to `'\0'`.
Initializing the output variables with sentinel values fixes the issue and makes failure cases deterministic.