### PR TITLE
Fixed memory leak on rank05/level1/polyset

### DIFF
--- a/.resources/rank05/level1/polyset/bag.hpp
+++ b/.resources/rank05/level1/polyset/bag.hpp
@@ -2,6 +2,10 @@
 
 class bag {
  public:
+  virtual ~bag()
+  {
+
+  };
 	virtual void insert (int) = 0;
 	virtual void insert (int *, int) = 0;
 	virtual void print() const = 0;

--- a/.resources/rank05/level1/polyset/main.cpp
+++ b/.resources/rank05/level1/polyset/main.cpp
@@ -37,6 +37,7 @@ int main(int argc, char **argv)
 
 	set sa(*a);
 	set st(*t);
+  int intArr[] = {1, 2, 3, 4};
 	for (int i = 1; i < argc; i++)
 	{
 		st.insert(atoi(argv[i]));
@@ -47,9 +48,11 @@ int main(int argc, char **argv)
 		sa.get_bag().print();
 		st.print();
 		sa.clear();
-		sa.insert((int[]){ 1, 2, 3, 4, }, 4);
+		sa.insert(intArr, sizeof(intArr) / sizeof(int));
 		std::cout << std::endl;
 	}
-
+  
+  delete a;
+  delete t;
 	return (0);
 }


### PR DESCRIPTION
The program leaks memory since we don't delete the two allocated object which the pointers (a) and (t) point to, and you can't simply just delete them since that won't compile unless you make the destructor virtual on the base class 'Bag' which is not.