### PR TITLE
fix(rank05 wrapper): fix output handling and pass detection logic

### DIFF
--- a/.resources/main/rank05_level_base.sh
+++ b/.resources/main/rank05_level_base.sh
@@ -98,10 +98,10 @@ while true; do
         test)
             clear
             echo -e "${GREEN}Running tester.sh...${RESET}"
-            output=$(./tester.sh 2>&1)
+			output=$(yes '' | ./tester.sh 2>&1 | tee tester_output.log)
             echo "$output" | tee tester_output.log
 
-            if echo "$output" | grep -q "PASSED"; then
+            if echo "$output" | grep -q "ALL TESTS PASSED!"; then
                 echo -e "${GREEN}${BOLD}✔️  Passed!${RESET}"
                 rm -f "$subject_file"
                 sleep 1
@@ -111,6 +111,9 @@ while true; do
                 sleep 1
           
             fi
+
+			echo
+            echo "Please type 'test' to test code, 'next' for next or 'exit' for exit."
             ;;
         next)
             echo -e "${BLUE}🔄 Picking a new subject...${RESET}"


### PR DESCRIPTION
This PR fixes multiple issues in the rank05 tester wrapper.

Why:
    Wrapper could hang waiting for user input when running tester.sh
    Success detection was unreliable and could produce false positives
    Tester output was not consistently visible or preserved
    User experience required manual interaction to regain prompt

Changes:
    Prevents hanging by piping automatic newlines into tester.sh
    Fixes success detection by checking the final "ALL TESTS PASSED!" marker
    Avoids false positives from partial matches like "PASSED" in Valgrind output
    Preserves tester output using tee (logs + stdout)
    Restores prompt automatically after tester execution

Result:
    Reliable execution without blocking on input
    Accurate success detection without false positives
    Consistent visibility and logging of tester output
    Improved usability with no manual interaction required