### PR TITLE
fix(rank05): improve cleanup behavior

### DIFF
--- a/.resources/main/rank05_level_base.sh
+++ b/.resources/main/rank05_level_base.sh
@@ -127,6 +127,10 @@ while true; do
             ;;
         exit)
             echo "Exiting..."
+			rendu_path="$base_dir/../../rendu"
+			if [[ -d "$rendu_path" && "$rendu_path" == *"/rendu" ]]; then
+				rm -rf "$rendu_path"
+			fi
             exit 0
             ;;
         *)

--- a/.resources/rank05/level1/vect2/tester.sh
+++ b/.resources/rank05/level1/vect2/tester.sh
@@ -7,6 +7,16 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+# Cleanup temporary files
+cleanup() {
+    rm -f ref_vect2 user_vect2 \
+          user_main.cpp user_vect2.hpp user_vect2.cpp \
+          user_main.tmp.cpp user_vect2.tmp.cpp \
+          ref_output.txt user_output.txt
+};
+
+trap cleanup EXIT INT TERM
+
 # Comprehensive Test Script for vect2
 echo -e "${BLUE}🔍 Running COMPREHENSIVE TESTING for vect2${NC}"
 echo "=========================================="
@@ -159,5 +169,3 @@ echo "======================================="
 # Wait for user to press enter before continuing
 read -rp "Press enter to continue..." dummy
 
-# Cleanup temporary files
-rm -f ref_vect2 user_vect2 user_main.cpp user_vect2.hpp user_vect2.cpp ref_output.txt user_output.txt


### PR DESCRIPTION
This PR fixes multiple cleanup issues in the rank05 wrapper and vect2 tester.

Why:
    Temporary files were not consistently cleaned up after execution
    Generated "rendu/" directory could persist and pollute subsequent runs
    Cleanup was not guaranteed on early exit or interruption

Changes:
    Removes the generated "rendu/" directory when exiting the rank05 wrapper
    Adds cleanup for temporary files generated by the vect2 tester
    Ensures cleanup is always executed using a trap on exit and interruption

Result:
    Clean working environment after each execution
    No leftover temporary files or directories
    Robust cleanup even in case of early exit or interruption
