### PR TITLE
fix(rank05/polyset tester): fix build, execution and cleanup issues

### DIFF
--- a/.resources/rank05/level1/polyset/array_bag.cpp
+++ b/.resources/rank05/level1/polyset/array_bag.cpp
@@ -3,7 +3,7 @@
 
 array_bag::array_bag() {
   size = 0;
-  data = nullptr;
+  data = NULL;
 }
 
 array_bag::array_bag(const array_bag &src) {
@@ -16,9 +16,9 @@ array_bag::array_bag(const array_bag &src) {
 
 array_bag &array_bag::operator=(const array_bag &src) {
 	if (this != &src) {
-		if (data != nullptr) {
+		if (data != NULL) {
 			delete[] data;
-			data = nullptr;
+			data = NULL;
 		}
 		size = src.size;
 		data = new int[size];
@@ -30,9 +30,9 @@ array_bag &array_bag::operator=(const array_bag &src) {
 }
 
 array_bag::~array_bag() {
-	if (data != nullptr) {
+	if (data != NULL) {
 		delete[] data;
-		data = nullptr;
+		data = NULL;
 	}
 }
 
@@ -42,7 +42,7 @@ void array_bag::insert(int item) {
 		new_data[i] = data[i];
 	}
 	new_data[size] = item;
-	if (data != nullptr) {
+	if (data != NULL) {
 		delete[] data;
 	}
 	data = new_data;
@@ -57,7 +57,7 @@ void array_bag::insert(int *items, int count) {
 	for (int i = 0; i < count; i++) {
 		new_data[size + i] = items[i];
 	}
-	if (data != nullptr) {
+	if (data != NULL) {
 		delete[] data;
 	}
 	data = new_data;
@@ -72,9 +72,9 @@ void array_bag::print() const {
 }
 
 void array_bag::clear() {
-	if (data != nullptr) {
+	if (data != NULL) {
 		delete[] data;
-		data = nullptr;
+		data = NULL;
 	}
 	size = 0;
 }

--- a/.resources/rank05/level1/polyset/bag.hpp
+++ b/.resources/rank05/level1/polyset/bag.hpp
@@ -2,6 +2,7 @@
 
 class bag {
  public:
+	virtual ~bag() {}
 	virtual void insert (int) = 0;
 	virtual void insert (int *, int) = 0;
 	virtual void print() const = 0;

--- a/.resources/rank05/level1/polyset/main.cpp
+++ b/.resources/rank05/level1/polyset/main.cpp
@@ -3,8 +3,8 @@
 #include "searchable_array_bag.hpp"
 #include "set.hpp"
 
-
 #include <iostream>
+#include <stdlib.h>
 
 int main(int argc, char **argv)
 {
@@ -47,9 +47,11 @@ int main(int argc, char **argv)
 		sa.get_bag().print();
 		st.print();
 		sa.clear();
-		sa.insert((int[]){ 1, 2, 3, 4, }, 4);
+		int values[] = {1, 2, 3, 4};
+		sa.insert(values, 4);
 		std::cout << std::endl;
 	}
-
+	delete a;
+	delete t;
 	return (0);
 }

--- a/.resources/rank05/level1/polyset/searchable_bag.hpp
+++ b/.resources/rank05/level1/polyset/searchable_bag.hpp
@@ -5,5 +5,6 @@
 class searchable_bag : virtual public bag // virtual inheritance
 {
  public:
+	virtual ~searchable_bag() {}
 	virtual bool has(int) const = 0; // verilen sayı bag'te var mı yok mu kontrolünü yapar
 };

--- a/.resources/rank05/level1/polyset/searchable_tree_bag.cpp
+++ b/.resources/rank05/level1/polyset/searchable_tree_bag.cpp
@@ -1,5 +1,5 @@
 #include "searchable_tree_bag.hpp"
-
+#include <cstddef>
 
 searchable_tree_bag::searchable_tree_bag()
 {
@@ -22,7 +22,7 @@ searchable_tree_bag& searchable_tree_bag::operator=(const searchable_tree_bag& s
 
 bool searchable_tree_bag::search(node* node, const int value) const
 {
-	if(node == nullptr)
+	if(node == NULL)
 		return(false);
 	if(node->value == value)
 		return(true);

--- a/.resources/rank05/level1/polyset/set.hpp
+++ b/.resources/rank05/level1/polyset/set.hpp
@@ -4,12 +4,12 @@ class set
 {
 	private:
 		searchable_bag& bag;
+		// disabled (C++98 equivalent of = delete)
+		set();
+		set(const set& source);
+		set& operator=(const set& source);
 	public:
-		set() = delete;
-		set(const set& source) = delete;
-		set& operator=(const set& source) = delete;
 		set(searchable_bag& s_bag);
-
 		bool has(int) const;
 		void insert (int);
 		void insert (int *, int);

--- a/.resources/rank05/level1/polyset/subject/array_bag.cpp
+++ b/.resources/rank05/level1/polyset/subject/array_bag.cpp
@@ -3,7 +3,7 @@
 
 array_bag::array_bag() {
   size = 0;
-  data = nullptr;
+  data = NULL;
 }
 
 array_bag::array_bag(const array_bag &src) {
@@ -16,9 +16,9 @@ array_bag::array_bag(const array_bag &src) {
 
 array_bag &array_bag::operator=(const array_bag &src) {
 	if (this != &src) {
-		if (data != nullptr) {
+		if (data != NULL) {
 			delete[] data;
-			data = nullptr;
+			data = NULL;
 		}
 		size = src.size;
 		data = new int[size];
@@ -30,9 +30,9 @@ array_bag &array_bag::operator=(const array_bag &src) {
 }
 
 array_bag::~array_bag() {
-	if (data != nullptr) {
+	if (data != NULL) {
 		delete[] data;
-		data = nullptr;
+		data = NULL;
 	}
 }
 
@@ -42,7 +42,7 @@ void array_bag::insert(int item) {
 		new_data[i] = data[i];
 	}
 	new_data[size] = item;
-	if (data != nullptr) {
+	if (data != NULL) {
 		delete[] data;
 	}
 	data = new_data;
@@ -57,7 +57,7 @@ void array_bag::insert(int *items, int count) {
 	for (int i = 0; i < count; i++) {
 		new_data[size + i] = items[i];
 	}
-	if (data != nullptr) {
+	if (data != NULL) {
 		delete[] data;
 	}
 	data = new_data;
@@ -72,9 +72,9 @@ void array_bag::print() const {
 }
 
 void array_bag::clear() {
-	if (data != nullptr) {
+	if (data != NULL) {
 		delete[] data;
-		data = nullptr;
+		data = NULL;
 	}
 	size = 0;
 }

--- a/.resources/rank05/level1/polyset/subject/bag.hpp
+++ b/.resources/rank05/level1/polyset/subject/bag.hpp
@@ -2,6 +2,7 @@
 
 class bag {
  public:
+	virtual ~bag() {}
 	virtual void insert (int) = 0;
 	virtual void insert (int *, int) = 0;
 	virtual void print() const = 0;

--- a/.resources/rank05/level1/polyset/subject/main.cpp
+++ b/.resources/rank05/level1/polyset/subject/main.cpp
@@ -1,6 +1,7 @@
 #include "searchable_bag.hpp"
 
 #include <iostream>
+#include <stdlib.h>
 
 int main(int argc, char **argv) {
   if (argc == 1)
@@ -40,16 +41,11 @@ int main(int argc, char **argv) {
     sa.get_bag().print();
     st.print();
     sa.clear();
-    sa.insert(
-        (int[]){
-            1,
-            2,
-            3,
-            4,
-        },
-        4);
+    int values[] = {1, 2, 3, 4};
+    sa.insert(values, 4);
     std::cout << std::endl;
   }
-
+  delete a;
+  delete t;
   return 0;
 }

--- a/.resources/rank05/level1/polyset/subject/searchable_bag.hpp
+++ b/.resources/rank05/level1/polyset/subject/searchable_bag.hpp
@@ -4,5 +4,6 @@
 
 class searchable_bag : virtual public bag {
 public:
-	virtual bool has(int) const = 0;
+    virtual ~searchable_bag() {}
+    virtual bool has(int) const = 0;
 };

--- a/.resources/rank05/level1/polyset/subject/tree_bag.cpp
+++ b/.resources/rank05/level1/polyset/subject/tree_bag.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 
 tree_bag::tree_bag() {
-	tree = nullptr;
+	tree = NULL;
 }
 
 tree_bag::tree_bag(const tree_bag &src) {
@@ -23,7 +23,7 @@ tree_bag &tree_bag::operator=(const tree_bag &src) {
 
 tree_bag::node *tree_bag::extract_tree() {
 	node *temp = tree;
-	tree = nullptr;
+	tree = NULL;
 	return temp;
 }
 
@@ -37,10 +37,10 @@ void tree_bag::insert(int item) {
 	// alloc new node
 	std::cout << "create node: " << item << std::endl;
 	new_node->value = item;
-	new_node->l = nullptr;
-	new_node->r = nullptr;
+	new_node->l = NULL;
+	new_node->r = NULL;
 
-	if (tree == nullptr) {
+	if (tree == NULL) {
 		// std::cout << "tree is null - adding" << std::endl;
 		tree = new_node;
 	} 
@@ -48,14 +48,14 @@ void tree_bag::insert(int item) {
 		node *current = tree;
 		while (true) {
 			if (item < current->value) {
-				if (current->l == nullptr) {
+				if (current->l == NULL) {
 					current->l = new_node;
 					break;
 				} else {
 					current = current->l;
 				}
 			} else if (item > current->value) {
-				if (current->r == nullptr) {
+				if (current->r == NULL) {
 					current->r = new_node;
 					break;
 				} else {
@@ -83,12 +83,12 @@ void tree_bag::print() const {
 
 void tree_bag::clear() {
 	destroy_tree(tree);
-	tree = nullptr;
+	tree = NULL;
 }
 
 // defined as static functions in the class
 void tree_bag::destroy_tree(node *current) {
-	if (current != nullptr) {
+	if (current != NULL) {
 		std::cout << "destroying value: " << current->value << std::endl;
 		destroy_tree(current->l);
 		destroy_tree(current->r);
@@ -97,7 +97,7 @@ void tree_bag::destroy_tree(node *current) {
 }
 
 void tree_bag::print_node(node *current) {
-	if (current != nullptr) {
+	if (current != NULL) {
 		print_node(current->l);
 		if (current->value != 0)
 			std::cout << current->value << " ";
@@ -106,8 +106,8 @@ void tree_bag::print_node(node *current) {
 }
 
 tree_bag::node *tree_bag::copy_node(node *current) {
-	if (current == nullptr) {
-		return nullptr;
+	if (current == NULL) {
+		return NULL;
 	} else {
 		node *new_node = new node;
 		new_node->value = current->value;

--- a/.resources/rank05/level1/polyset/subject/tree_bag.hpp
+++ b/.resources/rank05/level1/polyset/subject/tree_bag.hpp
@@ -28,5 +28,5 @@ public:
 private:
   static void destroy_tree(node *);
   static void print_node(node *);
-  static void *copy_node(node *);
+  static tree_bag::node *copy_node(node *);
 };

--- a/.resources/rank05/level1/polyset/tester.sh
+++ b/.resources/rank05/level1/polyset/tester.sh
@@ -14,7 +14,14 @@ echo ""
 
 # Compile the reference solution
 echo -e "${BLUE}📦 Compiling reference solution...${NC}"
-g++ -Wall -Wextra -Werror -std=c++98 -o ref_polyset main.cpp *.cpp
+g++ -Wall -Wextra -Werror -std=c++98 \
+  main.cpp \
+  array_bag.cpp \
+  tree_bag.cpp \
+  searchable_array_bag.cpp \
+  searchable_tree_bag.cpp \
+  set.cpp \
+  -o ref_polyset
 
 if [ $? -ne 0 ]; then
     echo -e "${RED}❌ Reference compilation failed!${NC}"
@@ -26,8 +33,6 @@ echo ""
 
 # Check if user solution exists
 USER_DIR="../../../../rendu/polyset"
-USER_CPP="$USER_DIR/polyset.cpp"
-USER_HPP="$USER_DIR/polyset.hpp"
 if [ ! -d "$USER_DIR" ]; then
     echo -e "${RED}❌ User solution folder not found: $USER_DIR${NC}"
     exit 1
@@ -35,10 +40,25 @@ fi
 
 # Copy and compile user solution
 echo -e "${BLUE}📦 Compiling user solution...${NC}"
-cp main.cpp user_main.cpp
-cp $USER_DIR/*.cpp . 2>/dev/null
-cp $USER_DIR/*.hpp . 2>/dev/null
-g++ -Wall -Wextra -Werror -std=c++98 -o user_polyset user_main.cpp *.cpp
+
+TMP_USER=$(mktemp -d)
+
+cp subject/*.cpp "$TMP_USER/"
+cp subject/*.hpp "$TMP_USER/"
+cp "$USER_DIR"/*.cpp "$TMP_USER/"
+cp "$USER_DIR"/*.hpp "$TMP_USER/"
+cp main.cpp "$TMP_USER/test_main.cpp"\
+
+g++ -Wall -Wextra -Werror -std=c++98 \
+  "$TMP_USER/test_main.cpp" \
+  "$TMP_USER/array_bag.cpp" \
+  "$TMP_USER/tree_bag.cpp" \
+  "$TMP_USER/searchable_array_bag.cpp" \
+  "$TMP_USER/searchable_tree_bag.cpp" \
+  "$TMP_USER/set.cpp" \
+  -I"$TMP_USER" \
+  -o user_polyset
+
 if [ $? -ne 0 ]; then
     echo -e "${RED}❌ User compilation failed!${NC}"
     exit 1
@@ -48,10 +68,12 @@ echo -e "${GREEN}✅ User compilation successful!${NC}"
 echo ""
 
 # Run both and capture output
+TEST_ARGS="10 20 30"
+
 echo -e "${BLUE}🚀 Running tests...${NC}"
-./ref_polyset > ref_output.txt 2>&1
+./ref_polyset $TEST_ARGS > ref_output.txt 2>&1
 echo "[DEBUG] Reference output:"; cat ref_output.txt
-./user_polyset > user_output.txt 2>&1
+./user_polyset $TEST_ARGS > user_output.txt 2>&1
 echo "[DEBUG] User output:"; cat user_output.txt
 
 # Compare outputs
@@ -83,7 +105,7 @@ valgrind_output=$(valgrind \
     --track-origins=yes \
     -s \
     --error-exitcode=1 \
-    ./user_polyset 2>&1)
+    ./user_polyset $TEST_ARGS 2>&1)
 
 exit_code=$?
 
@@ -157,4 +179,5 @@ echo "======================================="
 read -rp "Press enter to continue..." dummy
 
 # Cleanup temporary files
-rm -f ref_polyset user_polyset user_main.cpp *.cpp *.hpp ref_output.txt user_output.txt
+rm -f ref_polyset user_polyset ref_output.txt user_output.txt
+rm -rf "$TMP_USER"

--- a/.resources/rank05/level1/polyset/tree_bag.cpp
+++ b/.resources/rank05/level1/polyset/tree_bag.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 
 tree_bag::tree_bag() {
-	tree = nullptr;
+	tree = NULL;
 }
 
 tree_bag::tree_bag(const tree_bag &src) {
@@ -23,7 +23,7 @@ tree_bag &tree_bag::operator=(const tree_bag &src) {
 
 tree_bag::node *tree_bag::extract_tree() {
 	node *temp = tree;
-	tree = nullptr;
+	tree = NULL;
 	return temp;
 }
 
@@ -37,10 +37,10 @@ void tree_bag::insert(int item) {
 	// alloc new node
 	std::cout << "create node: " << item << std::endl;
 	new_node->value = item;
-	new_node->l = nullptr;
-	new_node->r = nullptr;
+	new_node->l = NULL;
+	new_node->r = NULL;
 
-	if (tree == nullptr) {
+	if (tree == NULL) {
 		// std::cout << "tree is null - adding" << std::endl;
 		tree = new_node;
 	}
@@ -48,14 +48,14 @@ void tree_bag::insert(int item) {
 		node *current = tree;
 		while (true) {
 			if (item < current->value) {
-				if (current->l == nullptr) {
+				if (current->l == NULL) {
 					current->l = new_node;
 					break;
 				} else {
 					current = current->l;
 				}
 			} else if (item > current->value) {
-				if (current->r == nullptr) {
+				if (current->r == NULL) {
 					current->r = new_node;
 					break;
 				} else {
@@ -83,12 +83,12 @@ void tree_bag::print() const {
 
 void tree_bag::clear() {
 	destroy_tree(tree);
-	tree = nullptr;
+	tree = NULL;
 }
 
 // defined as static functions in the class
 void tree_bag::destroy_tree(node *current) {
-	if (current != nullptr) {
+	if (current != NULL) {
 		std::cout << "destroying value: " << current->value << std::endl;
 		destroy_tree(current->l);
 		destroy_tree(current->r);
@@ -97,7 +97,7 @@ void tree_bag::destroy_tree(node *current) {
 }
 
 void tree_bag::print_node(node *current) {
-	if (current != nullptr) {
+	if (current != NULL) {
 		print_node(current->l);
 		if (current->value != 0)
 			std::cout << current->value << " ";
@@ -106,8 +106,8 @@ void tree_bag::print_node(node *current) {
 }
 
 tree_bag::node *tree_bag::copy_node(node *current) {
-	if (current == nullptr) {
-		return nullptr;
+	if (current == NULL) {
+		return NULL;
 	} else {
 		node *new_node = new node;
 		new_node->value = current->value;

--- a/.resources/rank05/level1/polyset/tree_bag.hpp
+++ b/.resources/rank05/level1/polyset/tree_bag.hpp
@@ -30,5 +30,5 @@ public:
 private:
   static void destroy_tree(node *);
   static void print_node(node *);
-  static node *copy_node(node *); // void* -> node* yapıldı
+  static tree_bag::node *copy_node(node *); // void* -> node* yapıldı
 };


### PR DESCRIPTION
This PR fixes multiple issues in the rank05 polyset tester and scaffold.

Why:
    Reference scaffold was not C++98 compatible, causing compilation conflicts
    Previous setup mixed reference and user files, causing compilation conflicts
    User build was not properly isolated
    Test execution did not consistently pass arguments to binaries
    Memory leaks existed in the test harness
    Temporary files were not always cleaned up

Changes:
    Makes reference and scaffold C++98-compatible (replace nullptr, remove = delete, fix includes, remove compound literals)
    Fixes build isolation by copying user files into a temporary directory (TMP_USER)
    Copies test main.cpp into TMP_USER and compiles it with -I"$TMP_USER"
    Ensures user compilation uses isolated files from TMP_USER
    Adds test arguments and runs both reference and user binaries with the same inputs
    Runs Valgrind with consistent arguments
    Fixes memory leaks in test harness by adding virtual destructors and deleting allocated objects
    Adds cleanup routine with safe removal of temporary files and TMP_USER directory

Result:
    Reliable reference compilation under C++98
    Clean separation between reference and user code
    Consistent and reproducible test execution
    No memory leaks in the test harness
    No leftover temporary files after execution