### PR TITLE
fix(rank05/bsq tester): ensure build isolation and robust success detection

### DIFF
--- a/.resources/rank05/level2/bsq/tester.sh
+++ b/.resources/rank05/level2/bsq/tester.sh
@@ -7,36 +7,49 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+
+# Cleanup temporary files
+cleanup() {
+    rm -rf ref_bsq user_bsq \
+        ref_output1.txt ref_output2.txt ref_output3.txt ref_output4.txt \
+        user_output1.txt user_output2.txt user_output3.txt user_output4.txt \
+        test1.map test2.map test3.map \
+        
+        if [ -n "$TMP_USER" ]; then
+            rm -rf "$TMP_USER"
+        fi
+};
+
+trap cleanup EXIT INT TERM
+
 echo -e "${BLUE}🔍 Running COMPREHENSIVE TESTING for bsq${NC}"
 echo "=========================================="
 echo ""
 
 # Paths
-RANDOM_FOLDER="../../../../rendu/bsq"
+USER_DIR="../../../../rendu/bsq"
 
 # Check if user solution exists
-if [ ! -d "$RANDOM_FOLDER" ]; then
+TMP_USER=$(mktemp -d)
+
+if [ ! -d "$USER_DIR" ]; then
     echo -e "${RED}❌ User rendu folder not found!${NC}"
     exit 1
 fi
 
-USER_C_FILES=$(find "$RANDOM_FOLDER" -name "*.c")
-USER_H_FILES=$(find "$RANDOM_FOLDER" -name "*.h")
+cp "$USER_DIR"/*.c "$TMP_USER/" 2>/dev/null
+cp "$USER_DIR"/*.h "$TMP_USER/" 2>/dev/null
 
+USER_H_FILES=$(find "$TMP_USER" -name "*.h")
+USER_C_FILES=$(find "$TMP_USER" -name "*.c")
 if [ -z "$USER_C_FILES" ] || [ -z "$USER_H_FILES" ]; then
     echo -e "${RED}❌ User solution not found: No .c or .h files${NC}"
     exit 1
 fi
 
-# Copy tester main to temporary file
-cp main.c temp_main.c
-
-# Copy user files into working folder
-cp "$RANDOM_FOLDER"/* .
-
 # Compile reference solution
 echo -e "${BLUE}📦 Compiling reference solution...${NC}"
-gcc -Wall -Wextra -Werror -std=c99 -o ref_bsq temp_main.c bsq.c
+gcc -Wall -Wextra -Werror -std=c99 -o ref_bsq main.c bsq.c
 if [ $? -ne 0 ]; then
     echo -e "${RED}❌ Reference compilation failed!${NC}"
     exit 1
@@ -46,7 +59,11 @@ echo ""
 
 # Compile user solution
 echo -e "${BLUE}📦 Compiling user solution...${NC}"
-gcc -Wall -Wextra -Werror -std=c99 -o user_bsq temp_main.c bsq.c
+gcc -Wall -Wextra -Werror -std=gnu99 \
+    $USER_C_FILES \
+  -I"$TMP_USER" \
+  -o user_bsq
+
 if [ $? -ne 0 ]; then
     echo -e "${RED}❌ User compilation failed!${NC}"
     exit 1
@@ -90,7 +107,15 @@ run_test() {
     local file=$2
     echo -e "${BLUE}🚀 Running Test $num...${NC}"
     ./ref_bsq "$file" > "ref_output${num}.txt" 2>&1
-    ./user_bsq "$file" > "user_output${num}.txt" 2>&1
+    timeout 2 ./user_bsq "$file" > "user_output${num}.txt" 2>&1
+    status=$?
+    if [ $status -eq 124 ]; then
+        echo -e "${RED}❌ User program timed out (possible infinite loop)${NC}"
+        exit 1
+    elif [ $status -ne 0 ]; then
+        echo -e "${RED}❌ User program crashed (exit code $status)${NC}"
+        exit 1
+    fi
 
     if diff -q "ref_output${num}.txt" "user_output${num}.txt" > /dev/null; then
         echo -e "${GREEN}✅ Test $num output matches reference!${NC}"
@@ -138,11 +163,8 @@ fi
 # Summary
 echo "======================================="
 if [ "$tests_passed" = true ]; then
-    echo -e "${GREEN}✅ PASSED!${NC}"
+    echo -e "${GREEN}✅ ALL TESTS PASSED!${NC}"
 else
     echo -e "${RED}❌ SOME TESTS FAILED!${NC}"
 fi
 echo "======================================="
-
-# Cleanup
-rm -f temp_main.c user_bsq ref_bsq


### PR DESCRIPTION
This PR fixes multiple issues in the rank05 bsq tester.

Why:
    Previous setup mixed reference and user files, causing compilation conflicts
    User compilation relied on user-provided main.c without clear isolation
    getline was not properly supported due to incorrect standard
    User program could hang indefinitely and block the tester
    Temporary files were not always cleaned up

Changes:
    Fixes build isolation by copying user files into a temporary directory (TMP_USER)
    Prevents user files from overwriting reference sources
    Compiles all user source files (including user main if present)
    Uses -std=gnu99 to ensure getline support
    Aligns success detection with wrapper by printing "ALL TESTS PASSED!"
    Adds timeout to prevent infinite loops from freezing the tester
    Validates USER_DIR before copying files
    Silences cp errors when no matching files are found
    Adds cleanup routine with trap to remove temporary files

Result:
    Reliable reference compilation
    Clean separation between reference and user code
    Consistent user compilation in an isolated environment
    Robust execution with protection against infinite loops
    No leftover temporary files after execution