### PR TITLE
Improve(rank05-wrapper): level1 exam scaffolding and pass detection

### DIFF
--- a/.resources/main/rank05_exam_mode.sh
+++ b/.resources/main/rank05_exam_mode.sh
@@ -44,16 +44,9 @@ prepare_subject() {
         [ ! -f "$base_dir/../../rendu/$chosen/$chosen.c" ] && touch "$base_dir/../../rendu/$chosen/$chosen.c"
         [ ! -f "$base_dir/../../rendu/$chosen/$chosen.h" ] && touch "$base_dir/../../rendu/$chosen/$chosen.h"
     else
-        # Level1 → create .cpp and .hpp
+        # Level1 → create .cpp and .hpp only if missing
         [ ! -f "$base_dir/../../rendu/$chosen/$chosen.cpp" ] && touch "$base_dir/../../rendu/$chosen/$chosen.cpp"
-
-        if [ ! -f "$base_dir/../../rendu/$chosen/$chosen.hpp" ]; then
-            if [ -f "$base_dir/../rank05/$level/$chosen/$chosen.hpp" ]; then
-                cp "$base_dir/../rank05/$level/$chosen/$chosen.hpp" "$base_dir/../../rendu/$chosen/$chosen.hpp"
-            else
-                touch "$base_dir/../../rendu/$chosen/$chosen.hpp"
-            fi
-        fi
+        [ ! -f "$base_dir/../../rendu/$chosen/$chosen.hpp" ] && touch "$base_dir/../../rendu/$chosen/$chosen.hpp"
     fi
 
     # Special case: Polyset for rank05 level1
@@ -101,7 +94,7 @@ while true; do
             output=$(./tester.sh 2>&1)
             echo "$output" | tee tester_output.log
 
-            if echo "$output" | grep -q "PASSED"; then
+            if echo "$output" | grep -q "ALL TESTS PASSED"; then
                 echo -e "${GREEN}${BOLD}✔️  Passed!${RESET}"
                 rm -f "$subject_file"
                 sleep 1

--- a/.resources/main/rank05_level_base.sh
+++ b/.resources/main/rank05_level_base.sh
@@ -41,16 +41,9 @@ setup_files() {
         [ ! -f "$base_dir/../../rendu/$chosen/$chosen.c" ] && touch "$base_dir/../../rendu/$chosen/$chosen.c"
         [ ! -f "$base_dir/../../rendu/$chosen/$chosen.h" ] && touch "$base_dir/../../rendu/$chosen/$chosen.h"
     else
-        # Level1 → create .cpp and .hpp
+        # Level1 → create .cpp and .hpp only if missing
         [ ! -f "$base_dir/../../rendu/$chosen/$chosen.cpp" ] && touch "$base_dir/../../rendu/$chosen/$chosen.cpp"
-
-        if [ ! -f "$base_dir/../../rendu/$chosen/$chosen.hpp" ]; then
-            if [ -f "$base_dir/../rank05/$level/$chosen/$chosen.hpp" ]; then
-                cp "$base_dir/../rank05/$level/$chosen/$chosen.hpp" "$base_dir/../../rendu/$chosen/$chosen.hpp"
-            else
-                touch "$base_dir/../../rendu/$chosen/$chosen.hpp"
-            fi
-        fi
+        [ ! -f "$base_dir/../../rendu/$chosen/$chosen.hpp" ] && touch "$base_dir/../../rendu/$chosen/$chosen.hpp"
     fi
 
     # Special case: Polyset for rank05 level1


### PR DESCRIPTION
This PR improves the realism of the rank05 level1 exam setup by removing automatic .hpp scaffolding.

Why:
Level1 exercises could automatically provide a pre-filled .hpp file in the user's rendu/ directory.
This exposed important implementation details before solving the exercise.
Header scaffolding reduced the need to infer:

* operator signatures
* const correctness
* member vs non-member operators
* overall class structure from the provided main

Changes:
* Removes automatic copying of existing .hpp scaffold files for rank05 level1 exercises.
* Level1 setup now creates empty .cpp and .hpp files only.
* Keeps the workflow closer to actual exam conditions where headers must be written from scratch.
* Harmonizes pass detection in exam mode by checking the final success marker (ALL TESTS PASSED) instead of the generic PASSED string.

Result:
* More realistic exam-mode practice environment.
* Encourages users to derive class interfaces directly from the subject and provided main.
* Improves training value for operator overloading and canonical class design exercises.
* Avoids potential false positives caused by intermediate checks printing PASSED.

Scope:
* rank05_exam_mode.sh
* rank05_level_base.sh

Applies only to rank05 level1 scaffolding behavior.
No impact on testers, grading logic, or exercise execution.