### PR TITLE
fix(exam mode): correct exit command handling in exam mode

### DIFF
--- a/.resources/main/rank02_exam_mode.sh
+++ b/.resources/main/rank02_exam_mode.sh
@@ -97,7 +97,7 @@ while true; do
             ;;
         exit)
             echo "Exiting..."
-            exit 0
+            exit 255 
             ;;
         *)
             echo "Please type 'test' to test code, 'next' for next or 'exit' for exit."

--- a/.resources/main/rank02_real_mode.sh
+++ b/.resources/main/rank02_real_mode.sh
@@ -9,6 +9,13 @@ run_level() {
     display_animation
     clear
     until bash rank02_exam_mode.sh rank02 level$level; do
+        if [ $? -eq 255 ]; then
+            rm -rf ../../rendu
+            rm -f /tmp/.current_subject_rank02_level$level;
+
+            exit 0
+        fi
+
         echo "$(tput setaf 1)Test failed. Try again.$(tput sgr0)"
         read -p "Press Enter to retry Level $level..."
         clear

--- a/.resources/main/rank03_exam_mode.sh
+++ b/.resources/main/rank03_exam_mode.sh
@@ -113,7 +113,7 @@ while true; do
             echo -e "${RED}Exiting exam mode...${RESET}"
             rm -f "$subject_file"
             cd "$base_dir"
-            exit 0
+            exit 255
             ;;
         *)
             echo -e "${RED}Unknown command. Use 'test', 'next', or 'exit'.${RESET}"

--- a/.resources/main/rank03_real_mode.sh
+++ b/.resources/main/rank03_real_mode.sh
@@ -9,6 +9,13 @@ run_level() {
     display_animation
     clear
     until bash rank03_exam_mode.sh rank03 level$level; do
+        if [ $? -eq 255 ]; then
+            rm -rf ../../rendu
+            rm -f /tmp/.current_subject_rank03_level$level;
+
+            exit 0
+        fi
+
         echo "$(tput setaf 1)Test failed. Try again.$(tput sgr0)"
         read -p "Press Enter to retry Level $level..."
         clear

--- a/.resources/main/rank04.sh
+++ b/.resources/main/rank04.sh
@@ -9,6 +9,13 @@ run_level() {
     display_animation
     clear
     until bash rank04_exam_mode.sh rank04 level$level; do
+        if [ $? -eq 255 ]; then
+            rm -rf ../../rendu
+            rm -f /tmp/.current_subject_rank04_level$level;
+
+            exit 0
+        fi
+
         echo "$(tput setaf 1)Test failed. Try again.$(tput sgr0)"
         read -p "Press Enter to retry Level $level..."
         clear

--- a/.resources/main/rank04_exam_mode.sh
+++ b/.resources/main/rank04_exam_mode.sh
@@ -96,7 +96,7 @@ while true; do
             ;;
         exit)
             echo "Exiting..."
-            exit 0
+            exit 255
             ;;
         *)
             echo "Please type 'test' to test code, 'next' for next or 'exit' for exit."

--- a/.resources/main/rank05.sh
+++ b/.resources/main/rank05.sh
@@ -9,6 +9,13 @@ run_level() {
     display_animation
     clear
     until bash rank05_exam_mode.sh rank05 level$level; do
+        if [ $? -eq 255 ]; then
+            rm -rf ../../rendu
+            rm -f /tmp/.current_subject_rank05_level$level;
+
+            exit 0
+        fi
+
         echo "$(tput setaf 1)Test failed. Try again.$(tput sgr0)"
         read -p "Press Enter to retry Level $level..."
         clear

--- a/.resources/main/rank05_exam_mode.sh
+++ b/.resources/main/rank05_exam_mode.sh
@@ -113,7 +113,7 @@ while true; do
             ;;
         exit)
             echo "Exiting..."
-            exit 0
+            exit 255 
             ;;
         *)
             echo "Please type 'test' to test code, 'next' for next or 'exit' for exit."

--- a/.resources/main/rank06.sh
+++ b/.resources/main/rank06.sh
@@ -16,6 +16,13 @@ run_question() {
     display_animation
     clear
     until bash rank06_exam_mode.sh rank06; do
+        if [ $? -eq 255 ]; then
+            rm -rf ../../rendu
+            rm -f /tmp/.current_subject_rank06_
+
+            exit 0
+        fi
+
         echo "$(tput setaf 1)Test failed. Try again.$(tput sgr0)"
         read -p "Press Enter to retry $question..."
         clear

--- a/.resources/main/rank06_exam_mode.sh
+++ b/.resources/main/rank06_exam_mode.sh
@@ -96,7 +96,7 @@ while true; do
             ;;
         exit)
             echo "Exiting..."
-            exit 0
+            exit 255
             ;;
         *)
             echo "Please type 'test' to test code, 'next' for next or 'exit' for exit."


### PR DESCRIPTION
Reason:

* The 'exit' command in exam(real) mode incorrectly returned '0' (success).
* This caused a false pass, advancing the user to the next level unintentionally.
* Temporary tracking files (e.g., '/tmp/.current_subject_*') were not deleted upon exit.
* Leftover tracking files prevented the exam from randomizing a new subject on the next launch.

Changes Made:

* Modified '*_exam_mode.sh' to return status code '255' on manual exit.
* Added a condition to catch status code '255' in 'rank0X_real_mode.sh' (for ranks 02, 03) and 'rank0X.sh' (for ranks 04, 05, 06).
* Added logic to remove the '../../rendu' directory when an abort is detected.
* Added logic to remove the specific '/tmp/.current_subject_*' tracking file before program termination.

Results:

* Entering 'exit' immediately aborts the program without advancing the level.
* The system environment is cleanly wiped (rendu and temp files removed).
* The exam successfully generates a new random subject when launched again.

Related Issues
* Fixes #27 