### PR TITLE
Fix cross-platform compatibility issues

### DIFF
--- a/.resources/main/functions.sh
+++ b/.resources/main/functions.sh
@@ -16,9 +16,9 @@ display_animation() {
             clear_screen
             printf "$(tput setaf 2)$(tput bold)Please wait... %s\n\n" "$frame"
             sleep $duration
-            $(tput sgr0)
+            tput sgr0
         done
-        $(tput sgr0)
+        tput sgr0
     done
-    $(tput sgr0)
+    tput sgr0
 }

--- a/.resources/main/intro.sh
+++ b/.resources/main/intro.sh
@@ -41,7 +41,13 @@ case $opt in
         ;;
     7)
         cd ../../rendu
-        open .
+        if command -v xdg-open &> /dev/null; then
+            xdg-open .
+        elif command -v open &> /dev/null; then
+            open .
+        else
+            echo "Current directory: $(pwd)"
+        fi
         cd ../.resources/main
         bash menu.sh
         exit 1

--- a/.resources/main/level_base.sh
+++ b/.resources/main/level_base.sh
@@ -152,7 +152,7 @@ fi
                 cd ../../../../
                 if [ -d rendu ]; then
                     mkdir -p trace
-                    cp -r rendu "trace/rendu_backup_$(date +%s)"
+                    cp -r rendu "trace/rendu_backup_$(date +%Y%m%d%H%M%S)"
                     rm -rf rendu
                 fi
                 cd .resources/main
@@ -163,7 +163,7 @@ fi
                 cd ../../../../
                 if [ -d rendu ]; then
                     mkdir -p trace
-                    cp -r rendu "trace/rendu_backup_$(date +%s)"
+                    cp -r rendu "trace/rendu_backup_$(date +%Y%m%d%H%M%S)"
                     rm -rf rendu
                 fi
                 exit 1

--- a/.resources/main/rank06_level.sh
+++ b/.resources/main/rank06_level.sh
@@ -117,7 +117,7 @@ while true; do
                 cd ../../../../
                 if [ -d rendu ]; then
                     mkdir -p trace
-                    cp -r rendu "trace/rendu_backup_$(date +%s)"
+                    cp -r rendu "trace/rendu_backup_$(date +%Y%m%d%H%M%S)"
                     rm -rf rendu
                 fi
                 cd .resources/main
@@ -128,7 +128,7 @@ while true; do
                 cd ../../../../
                 if [ -d rendu ]; then
                     mkdir -p trace
-                    cp -r rendu "trace/rendu_backup_$(date +%s)"
+                    cp -r rendu "trace/rendu_backup_$(date +%Y%m%d%H%M%S)"
                     rm -rf rendu
                 fi
                 exit 1


### PR DESCRIPTION
Replace `$(tput sgr0)` with `tput sgr0` — the command substitution was executing the escape sequence as a command, causing "command not found" errors in display_animation().

compatibility issues

- functions.sh: fix 'command not found' from $(tput sgr0) -> tput sgr0
- intro.sh: replace macOS-only 'open .' with xdg-open fallback
- level_base.sh, rank06_level.sh: replace non-portable date +%s with +%Y%m%d%H%M%S"