### PR TITLE
fix: enforce strict timeout and prevent orphan processes on infinite loops

### DIFF
--- a/.resources/main/rank02_exam_mode.sh
+++ b/.resources/main/rank02_exam_mode.sh
@@ -75,7 +75,26 @@ while true; do
         test)
             clear
             echo -e "${GREEN}Running tester.sh...${RESET}"
-            output=$(./tester.sh 2>&1)
+            ./tester.sh > tester_output.log 2>&1 &
+            pid=$!
+            slept=0
+            while [ $slept -lt 10 ] && kill -0 $pid 2>/dev/null; do
+                sleep 1
+                slept=$((slept+1))
+            done
+            
+            if kill -0 $pid 2>/dev/null; then
+                echo -e "${RED}${BOLD}TIMEOUT${RESET}"
+                echo "It can be because of infinite loop "
+                echo "Please check your code or just try again."
+                pkill -P $pid 2>/dev/null
+                killall -9 out1 out2 2>/dev/null
+                kill -9 $pid 2>/dev/null
+                sleep 1
+                exit 1
+            fi
+            
+            output=$(cat tester_output.log)
             echo "$output" | tee tester_output.log
 
             if echo "$output" | grep -q -E "PASSED|SUCCESS"; then

--- a/.resources/main/rank04_exam_mode.sh
+++ b/.resources/main/rank04_exam_mode.sh
@@ -74,7 +74,26 @@ while true; do
         test)
             clear
             echo -e "${GREEN}Running tester.sh...${RESET}"
-            output=$(./tester.sh 2>&1)
+            ./tester.sh > tester_output.log 2>&1 &
+            pid=$!
+            slept=0
+            while [ $slept -lt 10 ] && kill -0 $pid 2>/dev/null; do
+                sleep 1
+                slept=$((slept+1))
+            done
+            
+            if kill -0 $pid 2>/dev/null; then
+                echo -e "${RED}${BOLD}TIMEOUT${RESET}"
+                echo "It can be because of infinite loop "
+                echo "Please check your code or just try again."
+                pkill -P $pid 2>/dev/null
+                killall -9 out1 out2 2>/dev/null
+                kill -9 $pid 2>/dev/null
+                sleep 1
+                exit 1
+            fi
+            
+            output=$(cat tester_output.log)
             echo "$output" | tee tester_output.log
 
             if echo "$output" | grep -q "PASSED"; then

--- a/.resources/main/rank05_exam_mode.sh
+++ b/.resources/main/rank05_exam_mode.sh
@@ -91,7 +91,26 @@ while true; do
         test)
             clear
             echo -e "${GREEN}Running tester.sh...${RESET}"
-            output=$(./tester.sh 2>&1)
+            ./tester.sh > tester_output.log 2>&1 &
+            pid=$!
+            slept=0
+            while [ $slept -lt 10 ] && kill -0 $pid 2>/dev/null; do
+                sleep 1
+                slept=$((slept+1))
+            done
+            
+            if kill -0 $pid 2>/dev/null; then
+                echo -e "${RED}${BOLD}TIMEOUT${RESET}"
+                echo "It can be because of infinite loop "
+                echo "Please check your code or just try again."
+                pkill -P $pid 2>/dev/null
+                killall -9 out1 out2 2>/dev/null
+                kill -9 $pid 2>/dev/null
+                sleep 1
+                exit 1
+            fi
+            
+            output=$(cat tester_output.log)
             echo "$output" | tee tester_output.log
 
             if echo "$output" | grep -q "ALL TESTS PASSED"; then


### PR DESCRIPTION
### Description
Currently, the exam shell struggles to safely handle infinite loops written by students (e.g., an unclosed `while(1)` with a `malloc` inside). This creates two major issues across the codebase:

1. **In `_exam_mode.sh` scripts:** The tester is called synchronously (`output=$(./tester.sh 2>&1)`). If an infinite loop occurs, the shell hangs forever with no timeout mechanism.
2. **In `level_base.sh` and `rank06_level.sh`:** A 10-second timeout exists, but it only kills the parent bash script (`kill $pid`). The compiled C binaries (`out1` / `out2`) are left running in the background as immortal orphan processes (adopted by `launchd` on macOS or `init/systemd` on Linux).

### Impact
These orphan processes silently consume 100% CPU and endlessly hoard virtual memory. On both macOS and Linux, this extreme thermal pressure and memory exhaustion (swap saturation) triggers severe system instability, eventually leading to macOS `WindowServer` crashes in my case.

### Changes made
- **Added timeout to Exam Mode:** Updated all `rankXX_exam_mode.sh` scripts to run the tester in the background with a 10-second watchdog loop, matching the training mode logic.
- **Deep Cleanup:** Upgraded the timeout logic to perform a strict process cleanup. It now uses `pkill -P` and explicitly kills the compiled binaries (`killall -9 out1 out2 2>/dev/null`) to prevent any rogue background processes.
- **Maintained UI Consistency:** Carefully kept the original developer messages intact (`It can be because of infinite loop...`) so the user experience remains familiar and unchanged.

### How to test
1. Launch any training level or exam mode
2. Write an infinite loop in any C file in the `rendu` folder and type `test`.
3. Wait 10 seconds. The shell will safely catch the timeout, kill all underlying processes (verifiable via Activity Monitor / `htop`), and return to the prompt without freezing the host machine.